### PR TITLE
Swap nomnom (deprecated) with commander

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1482,6 +1482,11 @@
         "object-visit": "^1.0.0"
       }
     },
+    "commander": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
+      "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw=="
+    },
     "common-path-prefix": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-1.0.0.tgz",
@@ -2467,6 +2472,15 @@
           "dev": true,
           "optional": true
         },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -2476,15 +2490,6 @@
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
             "strip-ansi": "^3.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
@@ -2666,7 +2671,8 @@
     "has-color": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
+      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
+      "dev": true
     },
     "has-flag": {
       "version": "2.0.0",
@@ -3455,37 +3461,6 @@
       "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
       "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
       "dev": true
-    },
-    "nomnom": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-      "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
-      "requires": {
-        "chalk": "~0.4.0",
-        "underscore": "~1.6.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
-        },
-        "chalk": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-          "requires": {
-            "ansi-styles": "~1.0.0",
-            "has-color": "~0.1.0",
-            "strip-ansi": "~0.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
-        }
-      }
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -4912,6 +4887,15 @@
         }
       }
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -4941,15 +4925,6 @@
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "stringifier": {
@@ -5169,11 +5144,6 @@
       "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
       "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
       "dev": true
-    },
-    "underscore": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-      "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   },
   "dependencies": {
     "chalk": "^1.1.3",
-    "http-proxy": "^1.15.1",
-    "nomnom": "^1.8.1"
+    "commander": "^9.4.1",
+    "http-proxy": "^1.15.1"
   },
   "devDependencies": {
     "ava": "^0.16.0",

--- a/src/commandline.js
+++ b/src/commandline.js
@@ -1,44 +1,30 @@
-import nomnom from 'nomnom';
-import Path from 'path';
-import fs from 'fs';
-import { name, version } from '../package.json';
+import commander from "commander";
+import Path from "path";
+import fs from "fs";
+import { name, version } from "../package.json";
 
-const exists = path => fs.accessSync(absolutePath(path));
-const absolutePath = path => Path.isAbsolute(path) ? path : Path.resolve(process.cwd(), path);
-
-const options = {
-  hostname: {
-    abbr: 'n',
-    default: 'localhost'
-  },
-  source: {
-    abbr: 's',
-    default: 9001
-  },
-  target: {
-    abbr: 't',
-    default: 9000
-  },
-  cert: {
-    abbr: 'c',
-    default: Path.resolve(__dirname, '..', 'resources', 'localhost.cert'),
-    callback: exists
-  },
-  key: {
-    abbr: 'k',
-    default: Path.resolve(__dirname, '..', 'resources', 'localhost.key'),
-    callback: exists
-  },
-  config: {
-    abbr: 'o',
-    callback: exists,
-    transform: path => require(absolutePath(path))
-  },
-  version: {
-    abbr: 'v',
-    flag: true,
-    callback: () => version
-  }
+const exists = (path) => {
+  fs.accessSync(absolutePath(path));
+  return path;
 };
+const absolutePath = (path) => (Path.isAbsolute(path) ? path : Path.resolve(process.cwd(), path));
+const parseInteger = (value) => parseInt(value, 10);
 
-export default nomnom.script(name).options(options);
+const program = commander
+  .command(name)
+  .version(version, "-v, --version", "show version number")
+  .option("-n, --hostname <hostname>", "hostname for the server", "localhost")
+  .option("-s, --source <source>", "source port for the server", parseInteger, 9001)
+  .option("-t, --target <target>", "target port for the server", parseInteger, 9000)
+  .option(
+    "-c, --cert <cert>",
+    "path to SSL certificate",
+    exists,
+    Path.resolve(__dirname, "..", "resources", "localhost.cert")
+  )
+  .option("-k, --key <key>", "path to SSL key", exists, Path.resolve(__dirname, "..", "resources", "localhost.key"))
+  .option("-o, --config <config>", "path to configuration file", (path) => require(absolutePath(path)));
+
+export default {
+  parse: (args) => (args === undefined ? program.parse().opts() : program.parse(args, { from: "user" }).opts()),
+};


### PR DESCRIPTION
Dependabot found a vulnerability in underscore@~1.6.0 via a transitive dependency on nomnom@1.8.1.

This commit replaces nomnom with commander, keeping the changes contained in commandline.js.