### PR TITLE
Expose script as local-ssl-proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "url": "http://github.com/cameronhunter/local-ssl-proxy.git"
   },
   "license": "MIT",
-  "bin": "build/main.js",
+  "bin": {
+    "local-ssl-proxy": "build/main.js",
+  }
   "preferGlobal": true,
   "files": [
     "build",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "license": "MIT",
   "bin": {
-    "local-ssl-proxy": "build/main.js",
-  }
+    "local-ssl-proxy": "build/main.js"
+  },
   "preferGlobal": true,
   "files": [
     "build",


### PR DESCRIPTION
It's currently recommended to run this package using `npx`. There are many scenarios in which this works fine. However, when you want to install `local-ssl-proxy` locally in a project, it can be overly verbose.

Take a look at this real-world example:

```json
{
  "scripts": {
    "ssl-proxy": "dotenv cross-var npx local-ssl-proxy -- --source %SSL_PORT% --target %PORT%"
  }
}
```

Here's what it does:

1. It runs `dotenv-cli` to evaluate `.env` files
2. It runs `cross-var` to expose these environment variables in a npm script
3. Now I have to run `npx` in order to execute `local-ssl-proxy`

IMHO this last step is unnessary. This PR exposes the main script as `local-ssl-proxy`. This also allows installing the package globally, which some people might still prefer over using `npx`.