### PR TITLE
Add key and cert and hostname params to example config in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,17 @@ Example config:
 {
   "My proxy": {
     "source": 3001,
-    "target": 3000
+    "target": 3000,
+    "key": "localhost-key.pem",
+    "cert": "localhost.pem",
+    "hostname": "localhost"
   },
   "Another proxy": {
     "source": 9999,
-    "target": 9000
+    "target": 9000,
+    "key": "localhost-key.pem",
+    "cert": "localhost.pem",
+    "hostname": "localhost"
   }
 }
 ```


### PR DESCRIPTION
As explained here:

https://github.com/cameronhunter/local-ssl-proxy/issues/113

Using a config.json per the instructions fails:

```
{
  "My proxy": {
    "source": 3001,
    "target": 3000
  },
  "Another proxy": {
    "source": 9999,
    "target": 9000
  }
}
```

I've updated the config in README.MD to:

```
{
  "My proxy": {
    "source": 3001,
    "target": 3000,
    "key": "localhost-key.pem",
    "cert": "localhost.pem",
    "hostname": "localhost"
  },
  "Another proxy": {
    "source": 9999,
    "target": 9000,
    "key": "localhost-key.pem",
    "cert": "localhost.pem",
    "hostname": "localhost"
  }
}
```