### PR TITLE
add --default-target and --target-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ To start a proxy from port `9001` to `9000` run:
 local-ssl-proxy --source 9001 --target 9000
 ```
 
+Use `--target-path` and `--default-target` to proxy all queries matching `--target-path` to `--target` and all other
+queries to `--default-target`.
+
+```sh
+local-ssl-proxy --source 9001 --target 9000 --target-path /api --default-target 9002
+```
+
 Start your web server on the target port (`9000` in the example) and navigate to `https://localhost:<source-port>` ([https://localhost:9001](https://localhost:9001) in the example). You'll get a warning because the certificate is self-signed, this is safe to ignore during development.
 
 Using a dynamic DNS provider such as [noip](http://www.noip.com/personal/) or [DynDNS](http://dyn.com/dns/) or a static IP (if you have one) you can open a port in your firewall to allow external sites to call into your web server. This is great for developing applications using [OAuth](http://oauth.net/) without having to deploy externally.
@@ -53,7 +60,9 @@ Example config:
     "target": 9000,
     "key": "localhost-key.pem",
     "cert": "localhost.pem",
-    "hostname": "localhost"
+    "hostname": "localhost",
+    "targetPath": "/api",
+    "defaultTarget": 8000,
   }
 }
 ```

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -17,6 +17,8 @@ const program = createCommand(name)
   .option('-n, --hostname <hostname>', 'hostname for the server', 'localhost')
   .option('-s, --source <source>', 'source port for the server', parseInteger, 9001)
   .option('-t, --target <target>', 'target port for the server', parseInteger, 9000)
+  .option('-p, --target-path <target-path>', 'path to send all queries to target')
+  .option('-d, --default-target <target>', 'target which all other queries are proxied to', parseInteger)
   .option(
     '-c, --cert <cert>',
     'path to SSL certificate',
@@ -32,6 +34,8 @@ type Proxy = {
   target: number;
   cert: string;
   key: string;
+  targetPath?: string;
+  defaultTarget?: number;
 };
 
 type Config = { config: Record<string, Proxy> };

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,17 +2,18 @@
 
 import fs from 'fs';
 import proxy from 'http-proxy';
-import { red, bold, green } from 'ansi-colors';
+import { red, bold, green, blue } from 'ansi-colors';
 import { isProxy, parse } from './lib';
+import { createServer } from "node:http"
 
 const parsed = parse();
 
 const config = isProxy(parsed) ? { proxy: parsed } : parsed;
 
 for (const name of Object.keys(config)) {
-  const { hostname, target, key, cert, source } = config[name]!;
+  const { hostname, target, key, cert, source, defaultTarget, targetPath } = config[name]!;
 
-  proxy
+  const proxyServer = proxy
     .createServer({
       xfwd: true,
       ws: true,
@@ -27,12 +28,31 @@ for (const name of Object.keys(config)) {
     })
     .on('error', (e: any) => {
       console.error(red('Request failed to ' + name + ': ' + bold(e.code)));
-    })
-    .listen(source);
+    });
 
-  console.log(
-    green(
-      `Started ${isProxy(parsed) ? 'proxy' : bold(name)}: https://${hostname}:${source} → http://${hostname}:${target}`
-    )
-  );
+  if (defaultTarget !== undefined && targetPath !== undefined) {
+    const targetRegex = new RegExp(`^${targetPath}`);
+    const server = createServer(function(req, res) {
+      if (targetRegex.test(req.url || "")) {
+        proxyServer.web(req, res, { target: 'http://127.0.0.1:' + target });
+      } else {
+        proxyServer.web(req, res, { target: 'http://127.0.0.1:' + defaultTarget });
+      }
+    });
+    server.listen(source);
+    console.log(
+      blue(`Started ${isProxy(parsed) ? 'proxy' : bold(name)}:\n`),
+      green(`https://${hostname}:${source}/(${targetPath}) → http://${hostname}:${target}/*
+ https://${hostname}:${source}/* → http://${hostname}:${defaultTarget}/*`
+      )
+    );
+  } else {
+    proxyServer.listen(source);
+    console.log(
+      green(
+        `Started ${isProxy(parsed) ? 'proxy' : bold(name)}: https://${hostname}:${source} → http://${hostname}:${target}`
+      )
+    );
+  }
+
 }

--- a/test/lib.test.ts
+++ b/test/lib.test.ts
@@ -51,6 +51,26 @@ test('target', () => {
   expect(target).toBe(5000);
 });
 
+test('targetPath (default)', () => {
+  const { targetPath } = parse([]);
+  expect(targetPath).toBeUndefined();
+});
+
+test('targetPath', () => {
+  const { targetPath } = parse(['--target-path', '/api']);
+  expect(targetPath).toBe('/api');
+});
+
+test('defaultTarget (default)', () => {
+  const { defaultTarget } = parse([]);
+  expect(defaultTarget).toBeUndefined();
+});
+
+test('defaultTarget', () => {
+  const { defaultTarget } = parse(['--default-target', '5000']);
+  expect(defaultTarget).toBe(5000);
+});
+
 test('config', () => {
   const config = parse(['--config', require.resolve('./test-config.json')]);
   expect(config).toMatchInlineSnapshot(`
@@ -64,10 +84,12 @@ test('config', () => {
   },
   "Proxy 2": {
     "cert": "/etc/apache2/server.pem",
+    "defaultTarget": 5000,
     "hostname": "localhost",
     "key": "/etc/apache2/server.key",
     "source": 5001,
     "target": 3001,
+    "targetPath": "/api",
   },
 }
 `);

--- a/test/test-config.json
+++ b/test/test-config.json
@@ -11,6 +11,8 @@
     "source": 5001,
     "target": 3001,
     "cert": "/etc/apache2/server.pem",
-    "key": "/etc/apache2/server.key"
+    "key": "/etc/apache2/server.key",
+    "defaultTarget": 5000,
+    "targetPath": "/api"
   }
 }


### PR DESCRIPTION
So we can listen to two different apps, living on the same domain

```sh
local-ssl-proxy --source 9001 --target 9000 --target-path /api --default-target 9002
#  https://localhost:9001/(/api) → http://localhost:9000/*
#  https://localhost:9001/* → http://localhost:9002/*
```

